### PR TITLE
Maintain order of keys provided by bmlab

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-0.3.0
+0.2.1
  - enh: keep the order of data keys returned by bmlab for user convenience (#24)
  - setup: bump bmlab from 0.1.1 to 0.1.2 (#24)
 0.2.0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+0.3.0
+ - enh: keep the order of data keys returned by bmlab for user convenience (#24)
+ - setup: bump bmlab from 0.1.1 to 0.1.2 (#24)
 0.2.0
  - feat: support bmlab session file format (#18)
  - enh: prevent users from loading the same file twice

--- a/impose/formats/fmt_bm_bmlab.py
+++ b/impose/formats/fmt_bm_bmlab.py
@@ -25,7 +25,7 @@ def load_h5(path):
         channels = OrderedDict()
         for rep_key in rep_keys:
             session.set_current_repetition(rep_key)
-            keys = sorted(session.evaluation_model().get_parameter_keys())
+            keys = session.evaluation_model().get_parameter_keys()
 
             # If the file contains multiple repetitions, we
             # prepend the repetition key

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description=description,
     long_description=open('README.rst').read() if exists('README.rst') else '',
     install_requires=["czifile==2019.7.2",  # bc cgohlke and used for signature
-                      "bmlab>=0.1.1",
+                      "bmlab>=0.1.2",
                       "h5py>=2.10.0",
                       "numpy>=1.17.0",
                       "pyqt5>=5.15.0",


### PR DESCRIPTION
bmlab@0.1.2 returns the available keys as `OrderedDict`. This PR adjusts Impose to maintain this order. This way the most interesting keys (e.g. `brillouin_shift_f`) are now on top.