### PR TITLE
Correctly handle NaN values

### DIFF
--- a/impose/flblend.py
+++ b/impose/flblend.py
@@ -95,7 +95,7 @@ class FlBlend:
         stack_r = np.zeros((shape[0], shape[1], len(self)), dtype=float)
         stack_g = np.zeros((shape[0], shape[1], len(self)), dtype=float)
         stack_b = np.zeros((shape[0], shape[1], len(self)), dtype=float)
-        # We use this array to track the number of valid images
+        # We use this array to track the number of valid images pixel-wise
         # (we have to use float here, since np.nan only exists for floats)
         # This is necessary so we can correctly account for NaN values
         # that might occur e.g. for Brillouin data.
@@ -109,9 +109,9 @@ class FlBlend:
             stack_b[:, :, ii] = rgb[:, :, 2]
             stack_v[:, :, ii] = np.invert(np.isnan(rgb[:, :, 0]))
 
-        # Get the number of valid images for later normalization
+        # Get the number of valid images per pixel for later normalization
         norm_v = np.nansum(stack_v, axis=2)
-        # Zero valid images means all images were NaN
+        # Zero-valued pixels means all images were NaN at that pixel
         norm_v[norm_v == 0] = np.nan
 
         merged = np.zeros((shape[0], shape[1], 3), dtype=float)

--- a/impose/gui/visualize.py
+++ b/impose/gui/visualize.py
@@ -222,6 +222,10 @@ class Visualize(QtWidgets.QWidget):
         if override_metadata:
             ds.update_metadata(self.__getstate__())
         image = ds.get_image()
+        # If the image contains *only* nans, there is nothing to show
+        if np.isnan(image).all():
+            self.imageView.clear()
+            return
         sx, sy = ds.get_pixel_size()
         # Scaling/Normalization to the x-axis pixel size (y is scaled).
         self.imageView.setImage(image,

--- a/tests/test_flblend.py
+++ b/tests/test_flblend.py
@@ -34,6 +34,11 @@ def test_flb_blend_hsv():
     assert rgb[0, 0, 1] == 1 / len(fb)
     assert rgb[-1, -1, 0] == 1 / len(fb)
     assert np.allclose(rgb[-1, -1, 1], 0.45)  # did not check/fully understand
+    # NaN values should have no influence on the color
+    im3 = np.full((10, 10), np.nan)
+    fb.add_image(im3, hue=0)
+    rgb_nan = fb.blend(mode="hsv")
+    assert (rgb_nan == rgb).all()
 
 
 def test_flb_blend_rgb():
@@ -47,6 +52,11 @@ def test_flb_blend_rgb():
     assert rgb[0, 0, 1] == 1 / len(fb)
     assert rgb[-1, -1, 0] == 1 / len(fb)
     assert rgb[-1, -1, 1] == 0
+    # NaN values should have no influence on the color
+    im3 = np.full((10, 10), np.nan)
+    fb.add_image(im3, hue=0)
+    rgb_nan = fb.blend(mode="rgb")
+    assert (rgb_nan == rgb).all()
 
 
 def test_fli_get_hsv():
@@ -56,6 +66,13 @@ def test_fli_get_hsv():
     assert np.all(hsv[:, :, 0] == 123/255)
     assert np.all(hsv[:, :, 1] == 1)
     assert np.all(hsv[:, :, 2] != 1), "b/c different value of the image"
+    # Test behaviour for NaN values
+    image = np.ndarray((1, 3), buffer=np.array([0, np.nan, 1]))
+    fi = flblend.FlImage(image=image, hue=123)
+    hsv = fi.get_hsv()
+    assert np.allclose(hsv[:, 0, :], [0, 0, 0])
+    assert np.all(np.isnan(hsv[:, 1, :]))
+    assert np.allclose(hsv[:, 2, :], [123/255, 1, 1])
 
 
 @pytest.mark.parametrize("hue", [0, "#FF0000", [255, 0, 0], (255, 0, 0)])


### PR DESCRIPTION
This fixes the handling of NaN values in Impose. Impose does not complain anymore when a map contains (only) NaN values.
I also adjusted the calculation or RGV and HSV values so that NaN values do not affect the resulting colors anymore (they are treated as if they don't exist now).

Closes #25.