### PR TITLE
Better handle empty image view

### DIFF
--- a/impose/gui/visualize.py
+++ b/impose/gui/visualize.py
@@ -147,7 +147,13 @@ class Visualize(QtWidgets.QWidget):
         # get the image item
         img = self.imageView.getImageItem()
         # get the raw data
-        data = np.array(self.imageView.image)[:, :, 0]
+        data = np.array(self.imageView.image)
+        # If self.imageView is empty (e.g. because it was
+        # cleared due to all NaN values) the data array
+        # will be zero-dimensional
+        if data.ndim < 3:
+            return None
+        data = data[:, :, 0]
         # transform for mapping from geometry to data coordinates
         _, tr = roi.getArraySlice(data, img)
         return tr


### PR DESCRIPTION
The image view can be empty when images with only NaN values are viewed. In this case `np.array(self.image_view.image)` results in a zero-dimensional array, which cannot be indexed.

I try to account for this here. Closes #36.