### PR TITLE
Add Github deploy action

### DIFF
--- a/.github/workflows/deploy_github.yml
+++ b/.github/workflows/deploy_github.yml
@@ -1,0 +1,65 @@
+name: Deploy to GitHub Releases
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ['3.9']
+        os: [macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.9
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+        pip install -e .
+    - name: Build app for Mac
+      if: runner.os == 'macOS'
+      working-directory: ./build-recipes
+      run: |
+        bash ./macos_build_app.sh Impose $(python -m impose --version)
+    - name: Build app for Win
+      if: runner.os == 'windows'
+      working-directory: ./build-recipes
+      run: |
+        pip install -r win_build_requirements.txt
+        pyinstaller -y --log-level=WARN win_Impose.spec
+        .\dist\Impose\\Impose.exe --version
+        python win_make_iss.py
+        iscc /Q win_impose.iss
+    - name: Release macOS assets
+      if: runner.os == 'macOS'
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Impose ${{ github.ref_name }}
+        draft: true
+        prerelease: false
+        body: |
+            ![](https://img.shields.io/github/downloads/GuckLab/Impose/${{ github.ref_name }}/total.svg)
+        files: |
+          ./build-recipes/dist/Impose_${{ github.ref_name }}_macosx.dmg
+          ./build-recipes/dist/Impose_${{ github.ref_name }}_macosx.pkg
+    - name: Release windows assets
+      if: runner.os == 'windows'
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Impose ${{ github.ref_name }}
+        draft: true
+        prerelease: false
+        body: |
+            ![](https://img.shields.io/github/downloads/GuckLab/Impose/${{ github.ref_name }}/total.svg)
+        files: |
+          ./build-recipes/Output/Impose_${{ github.ref_name }}_win_64bit_setup.exe


### PR DESCRIPTION
This adds a github action to create PKG, DMG and EXE packages for macOS and Win, which get added to an automatically created release draft. Works well for BMicro.