### PR TITLE
Lock shapely to fix macOS DMG packages

### DIFF
--- a/build-recipes/macos_build_requirements.txt
+++ b/build-recipes/macos_build_requirements.txt
@@ -1,1 +1,2 @@
 pyinstaller>=5.0
+shapely<1.8.1


### PR DESCRIPTION
This fixes the DMG package builds which show a `Error while signing the bundle: codesign command (['codesign', '-s', '-', '--force', '--all-architectures', '--timestamp', '--deep', '/Users/runner/work/impose/impose/build-recipes/dist/Impose.app']) failed with error code 1` error currently.