### PR TITLE
Close bmlab session after loading data

### DIFF
--- a/impose/formats/fmt_bm_bmlab.py
+++ b/impose/formats/fmt_bm_bmlab.py
@@ -39,6 +39,8 @@ def load_h5(path):
                     evc.get_data(key)
                 channels[key_prefix + key] = data
 
+        session.clear()
+
         # create a unique signature for this dataset
         p1 = get_valid_source(path)
         p2 = get_session_file_path(p1)


### PR DESCRIPTION
Currently the files loaded by bmlab are locked until Impose is quit. Since we only need them once to load the data, this PR fixes this.