### PR TITLE
Pin bmlab version to last version compatible

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,7 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update
-        sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libegl1-mesa
+        sudo apt-get install -y xvfb libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xinput0 libxcb-xfixes0 libegl1-mesa libxcb-shape0
         # start xvfb in the background
         sudo /usr/bin/Xvfb $DISPLAY -screen 0 1280x1024x24 &
     - name: Install dependencies

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     description=description,
     long_description=open('README.rst').read() if exists('README.rst') else '',
     install_requires=["czifile==2019.7.2",  # bc cgohlke and used for signature
-                      "bmlab>=0.2.3",
+                      "bmlab==0.5.1",
                       "h5py>=2.10.0",
                       "numpy>=1.17.0",
                       "pyqt6>=6.2.0",


### PR DESCRIPTION
This pins bmlab to the last version compatible with the current status of Impose (bmlab >= 0.6.0 had file format changes) and fixes the check pipeline which got broken with an Ubuntu update probably. Necessary for #54.